### PR TITLE
added comment to usb_desc.c

### DIFF
--- a/teensy/avr/cores/teensy3/usb_desc.c
+++ b/teensy/avr/cores/teensy3/usb_desc.c
@@ -34,7 +34,7 @@
 #include "usb_desc.h"
 #ifdef NUM_ENDPOINTS
 #ifdef OS_DESC_VERSION
-#include "usb_os_desc.h" // XInput
+#include "usb_os_desc.h" // XInput - Comment from TuFFrabit - This file seems to be missing from the repo. It is causing compilation errors.
 #endif
 #include "usb_names.h"
 #include "kinetis.h"


### PR DESCRIPTION
@joshtsen 

Hey, I couldn't PR to your repo, so I forked and PR'd to the fork. Hope the comment in the file makes sense. Basically it seems impossible to compile at the least because of a missing usb_os_desc.h file. Perhaps do you have that file and forgot to include it? Am I dumb and just missing something? I believe that file to perhaps also contain some other things needed to successfully compile OS_DESC identifiers. Below is the full compilation error output from my IDE:

`C:\Users\XXXXX\dev\arudinotest\arduino-1.8.13-windows\arduino-1.8.13\hardware\teensy\avr\cores\teensy3\usb_desc.c:37:35: fatal error: usb_os_desc.h: No such file or directory
compilation terminated.
C:\Users\XXXXX\dev\arudinotest\arduino-1.8.13-windows\arduino-1.8.13\hardware\teensy\avr\cores\teensy3\usb_dev.c: In function 'usb_setup':
C:\Users\XXXXX\dev\arudinotest\arduino-1.8.13-windows\arduino-1.8.13\hardware\teensy\avr\cores\teensy3\usb_dev.c:501:9: error: 'OS_DESC_REQANDTYPE' undeclared (first use in this function)
    case OS_DESC_REQANDTYPE: // 0xA5C0
         ^
C:\Users\XXXXX\dev\arudinotest\arduino-1.8.13-windows\arduino-1.8.13\hardware\teensy\avr\cores\teensy3\usb_dev.c:501:9: note: each undeclared identifier is reported only once for each function it appears in
C:\Users\XXXXX\dev\arudinotest\arduino-1.8.13-windows\arduino-1.8.13\hardware\teensy\avr\cores\teensy3\usb_dev.c:503:31: error: 'usb_extended_compat_id_descriptor' undeclared (first use in this function)
      data = (const uint8_t *)&usb_extended_compat_id_descriptor;
                               ^
C:\Users\XXXXX\dev\arudinotest\arduino-1.8.13-windows\arduino-1.8.13\hardware\teensy\avr\cores\teensy3\usb_dev.c:521:9: error: 'OS_DESC_REQANDTYPE_IF' undeclared (first use in this function)
    case OS_DESC_REQANDTYPE_IF: // 0xA5C1
         ^
Error compiling for board Teensy LC.
`